### PR TITLE
Optimized Tiny Sound Font Implementation and Sample Generation Settings

### DIFF
--- a/src/fx.cpp
+++ b/src/fx.cpp
@@ -116,7 +116,6 @@ SND_InitSound(
 
     dig_flag = 0;
     fx_device = SND_NONE;
-
     music_volume = INI_GetPreferenceLong("Music", "Volume", 127);
     music_card = INI_GetPreferenceLong("Music", "CardType", M_NONE);
     sys_midi = INI_GetPreferenceLong("Setup", "sys_midi", 0);
@@ -125,6 +124,10 @@ SND_InitSound(
     core_midi_port = INI_GetPreferenceLong("Setup", "core_midi_port", 0);
     alsaclient = INI_GetPreferenceLong("Setup", "alsa_output_client", 128);
     alsaport = INI_GetPreferenceLong("Setup", "alsa_output_port", 0);
+    music_samplesperloop = INI_GetPreferenceLong("Music", "SamplesPerLoop", 16);
+
+    if(music_samplesperloop < 1 || music_samplesperloop > spec.samples)
+        music_samplesperloop = 16;
 
     switch (music_card)
     {

--- a/src/i_oplmusic.cpp
+++ b/src/i_oplmusic.cpp
@@ -1369,6 +1369,5 @@ musdevice_t mus_device_opl = {
     ControllerEvent,
     PitchBendEvent,
     ProgramChgEvent,
-    AllOffEvent,
-    0
+    AllOffEvent
 };

--- a/src/mpualsa.cpp
+++ b/src/mpualsa.cpp
@@ -255,7 +255,6 @@ musdevice_t mus_device_alsa = {
     ControllerEvent,
     PitchBendEvent,
 	ProgramEvent,
-	AllNotesOffEvent,
-	0
+	AllNotesOffEvent
 };
 #endif

--- a/src/mpucorea.cpp
+++ b/src/mpucorea.cpp
@@ -544,7 +544,6 @@ musdevice_t mus_device_corea = {
     ControllerEvent,
     PitchBendEvent,
     ProgramEvent,
-	AllNotesOffEvent,
-    0
+	AllNotesOffEvent
 };    
 #endif

--- a/src/mpucorem.cpp
+++ b/src/mpucorem.cpp
@@ -266,7 +266,6 @@ musdevice_t mus_device_corem = {
     ControllerEvent,
     PitchBendEvent,
     ProgramEvent,
-    AllNotesOffEvent,
-    0
+    AllNotesOffEvent
 };
 #endif

--- a/src/mputsf.cpp
+++ b/src/mputsf.cpp
@@ -35,12 +35,9 @@ TSF_Init(
 )
 {
     char fn[128];
-    #ifdef __SWITCH__
-        strcpy(fn, RAP_SD_DIR "TimGM6mb.sf2");
-    #else
-        INI_GetPreference("Setup", "SoundFont", fn, 127, "TimGM6mb.sf2");
-        // Load the SoundFont from a file
-    #endif
+
+    INI_GetPreference("Setup", "SoundFont", fn, 127, "TimGM6mb.sf2");
+    // Load the SoundFont from a file
 
     g_TinySoundFont = tsf_load_filename(fn);
 
@@ -214,6 +211,5 @@ musdevice_t mus_device_tsf = {
     ControllerEvent,
     PitchBendEvent,
     ProgramEvent,
-    AllNotesOffEvent,
-    1
+    AllNotesOffEvent
 };

--- a/src/mpuwinmm.cpp
+++ b/src/mpuwinmm.cpp
@@ -223,7 +223,6 @@ musdevice_t mus_device_winmm = {
     ControllerEvent,
     PitchBendEvent,
     ProgramEvent,
-    AllNotesOffEvent,
-    0
+    AllNotesOffEvent
 };
 #endif // _WIN32

--- a/src/musapi.cpp
+++ b/src/musapi.cpp
@@ -8,6 +8,8 @@
 
 static int musrate = 70;
 static int musfaderate = 50;
+
+int music_samplesperloop = 1;
 int music_init;
 int music_startoffset;
 int music_len;
@@ -592,25 +594,27 @@ MUS_Mix(
 )
 {
     int i;
-    
+    int mRate = musrate * music_samplesperloop;
+    int fRate = musfaderate * music_samplesperloop;
+    int gRate = gssrate * music_samplesperloop;
+    int SPLx2 = music_samplesperloop * 2;
+
     if (!music_init || !music_device || !music_device->Mix)
         return;
-    if(music_device->sampleDirect)
-        music_device->Mix(stream, len);
 
-    for (i = 0; i < len; i++)
+    for (i = 0; i < len; i+=music_samplesperloop)
     {
-        if(!music_device->sampleDirect)
-            music_device->Mix(stream, 1);
 
-        music_cnt += musrate;
+        music_device->Mix(stream, music_samplesperloop);
+
+        music_cnt += mRate;
         
         while (music_cnt >= fx_freq)
         {
             music_cnt -= fx_freq;
             MUS_Service();
         }
-        music_cnt2 += musfaderate;
+        music_cnt2 += fRate;
         
         while (music_cnt2 >= fx_freq)
         {
@@ -620,7 +624,7 @@ MUS_Mix(
         
         if (gsshack)
         {
-            music_cnt3 += gssrate;
+            music_cnt3 += gRate;
             
             while (music_cnt3 >= fx_freq)
             {
@@ -628,8 +632,8 @@ MUS_Mix(
                 GSS_Service();
             }
         }
-        if(!music_device->sampleDirect)
-            stream += 2;
+        
+            stream += SPLx2;
     }
 }
 

--- a/src/musapi.h
+++ b/src/musapi.h
@@ -13,9 +13,9 @@ struct musdevice_t {
     void (*PitchBendEvent)(unsigned int chan, int bend);
     void (*ProgramEvent)(unsigned int chan, unsigned int param);
     void (*AllNotesOffEvent)(unsigned int chan, unsigned int param);
-    int sampleDirect;
 };
 
+extern int music_samplesperloop;
 extern musdevice_t mus_device_opl, mus_device_winmm, mus_device_tsf, mus_device_alsa, mus_device_corea, mus_device_corem;
 extern musdevice_t *music_device;
 


### PR DESCRIPTION
Removed the need for an additional audio stream for Tiny Sound Font, streamlining audio processing.
Adopted the Mix callback approach, mirroring the OPL3 music system for improved performance and consistency.

Introduced a configurable setting, SamplesPerLoop, in the MUSIC section of the INI file.
SamplesPerLoop allows the user to specify the number of samples to generate per loop of the MUS_Mix functions for loop, optimizing sample generation and setup time.
Defaults to 16 samples per loop, a significant improvement over the original 1 sample per loop setting.
