### PR TITLE
Fix lack of sound effects on big-endian systems

### DIFF
--- a/src/fx.cpp
+++ b/src/fx.cpp
@@ -779,8 +779,7 @@ SFX_PlayPatch(
     int priority
 )
 {
-    int type = *(int16_t*)patch;
-    type = LE_LONG(type);
+    int type = LE_SHORT(*(int16_t*)patch);
     
     switch (type)
     {


### PR DESCRIPTION
The swap of the patch type was wrong, so that ended in the default case with no special action. The fix makes the sound effects working (tested on Debian ppc64).

Related to issue #15